### PR TITLE
Removing trailing new line from checksum output

### DIFF
--- a/DscBuildHelpers/Public/Compress-DscResourceModule.ps1
+++ b/DscBuildHelpers/Public/Compress-DscResourceModule.ps1
@@ -23,8 +23,8 @@ function Compress-DscResourceModule {
                 Write-Verbose "Publishing Module $(Split-Path -parent $Module.Path) to $DscBuildOutputModules"
                 $destinationPath = Join-Path -Path $DscBuildOutputModules -ChildPath "$($module.Name)_$($module.Version).zip"
                 Compress-Archive -Path "$($module.ModuleBase)\*" -DestinationPath $destinationPath
-                
-                (Get-FileHash -Path $destinationPath).Hash | Set-Content -Path "$destinationPath.checksum"
+
+                (Get-FileHash -Path $destinationPath).Hash | Set-Content -Path "$destinationPath.checksum" -NoNewline
             }
         }
     }


### PR DESCRIPTION
As Liam stated (Issue: https://github.com/gaelcolas/DscBuildHelpers/issues/6), adding -NoNewLine to the Set-Content removes the new line from the checksum file which fixes the issue. 

Herewith PR.