### PR TITLE
Update for PowerShell 7 / PSDesiredStateConfiguration 2 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed TypeConstraint, 'MSFT_KeyValuePair' should be ignored.
+- Initialize-DscResourceMetaInfo:
+  - Fixed TypeConstraint, 'MSFT_KeyValuePair' should be ignored.
+  - Fixed non-working caching test.
+  - Added PassThru pattern for easier debugging.
+  - Considering CIM instances names DSC_* in addition to MSFT_*.
+- Get-DscResourceFromModuleInFolder:
+  - Redesigned the function. It did not work with PowerShell 7 and
+    PSDesiredStateConfiguration 2.0.7.
+- Changed the remaining lines in alignment to PR #14.

--- a/source/Private/Get-StandardCimType.ps1
+++ b/source/Private/Get-StandardCimType.ps1
@@ -1,0 +1,54 @@
+function Get-StandardCimType
+{
+    $types = @{
+        Boolean               = 'System.Boolean'
+        UInt8                 = 'System.Byte'
+        SInt8                 = 'System.SByte'
+        UInt16                = 'System.UInt16'
+        SInt16                = 'System.Int16'
+        UInt32                = 'System.UInt32'
+        SInt32                = 'System.Int32'
+        UInt64                = 'System.UInt64'
+        SInt64                = 'System.Int64'
+        Real32                = 'System.Single'
+        Real64                = 'System.Double'
+        Char16                = 'System.Char'
+        DateTime              = 'System.DateTime'
+        String                = 'System.String'
+        Reference             = 'Microsoft.Management.Infrastructure.CimInstance'
+        Instance              = 'Microsoft.Management.Infrastructure.CimInstance'
+        BooleanArray          = 'System.Boolean[]'
+        UInt8Array            = 'System.Byte[]'
+        SInt8Array            = 'System.SByte[]'
+        UInt16Array           = 'System.UInt16[]'
+        SInt16Array           = 'System.Int16[]'
+        UInt32Array           = 'System.UInt32[]'
+        SInt32Array           = 'System.Int32[]'
+        UInt64Array           = 'System.UInt64[]'
+        SInt64Array           = 'System.Int64[]'
+        Real32Array           = 'System.Single[]'
+        Real64Array           = 'System.Double[]'
+        Char16Array           = 'System.Char[]'
+        DateTimeArray         = 'System.DateTime[]'
+        StringArray           = 'System.String[]'
+
+        MSFT_Credential       = 'System.Management.Automation.PSCredential'
+        'MSFT_KeyValuePair[]' = 'System.Collections.Hashtable'
+        MSFT_KeyValuePair     = 'System.Collections.Hashtable'
+    }
+
+    try
+    {
+        $types.GetEnumerator() | ForEach-Object {
+            $null = Invoke-Expression -Command "[$($_.Value)]" -ErrorAction Stop
+            [PSCustomObject]@{
+                CimType    = $_.Key
+                DotNetType = $_.Value
+            }
+        }
+    }
+    catch
+    {
+        Write-Error -Message "Failed to load CIM Types. The error was: $($_.Exception.Message)"
+    }
+}

--- a/source/Public/Get-DscSplattedResource.ps1
+++ b/source/Public/Get-DscSplattedResource.ps1
@@ -63,8 +63,7 @@ function Get-DscSplattedResource
 
                     foreach ($cimSubProperty in $cimPropertyValue.GetEnumerator())
                     {
-                        $null = $stringBuilder.AppendLine("$($cimSubProperty.Name) = `$(`$Parameters['$PropertyName'][$($i)]['$($cimSubProperty.Name)'])")
-
+                        $null = $stringBuilder.AppendLine("$($cimSubProperty.Name) = `$Parameters['$PropertyName'][$($i)]['$($cimSubProperty.Name)']")
                     }
 
                     $null = $stringBuilder.AppendLine("}")
@@ -77,7 +76,7 @@ function Get-DscSplattedResource
             {
                 foreach ($cimProperty in $cimProperties.GetEnumerator())
                 {
-                    $null = $stringBuilder.AppendLine("$($cimProperty.Name) = `$(`$Parameters['$PropertyName']['$($cimProperty.Name)'])")
+                    $null = $stringBuilder.AppendLine("$($cimProperty.Name) = `$Parameters['$PropertyName']['$($($cimProperty.Name))']")
                 }
 
                 $null = $stringBuilder.AppendLine("}")

--- a/source/Public/Get-ModuleFromFolder.ps1
+++ b/source/Public/Get-ModuleFromFolder.ps1
@@ -1,64 +1,69 @@
-﻿function Get-ModuleFromFolder {
+﻿function Get-ModuleFromFolder
+{
     [CmdletBinding()]
-    [OutputType('System.Management.Automation.PSModuleInfo[]')]
+    [OutputType([System.Management.Automation.PSModuleInfo[]])]
     param (
-        [Parameter(
-            Mandatory,
-            ValueFromPipeline,
-            ValueFromPipelineByPropertyName
-        )]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
-        [io.DirectoryInfo[]]
+        [System.IO.DirectoryInfo[]]
         $ModuleFolder,
-        
+
+        [Parameter()]
         [AllowNull()]
         [Microsoft.PowerShell.Commands.ModuleSpecification[]]
-        $ExcludedModules = $null
+        $ExcludedModules
     )
 
-    Begin {
-        $AllModulesInFolder = @()
+    Begin
+    {
+        $allModulesInFolder = @()
     }
 
-    Process {
-        foreach ($Folder in $ModuleFolder) {
+    Process
+    {
+        foreach ($Folder in $ModuleFolder)
+        {
             Write-Debug -Message "Replacing Module path with $Folder"
-            $OldPSModulePath = $env:PSModulePath
+            $oldPSModulePath = $env:PSModulePath
             $env:PSModulePath = $Folder
-            Write-Debug -Message "Discovering modules from folder"
-            $AllModulesInFolder += Get-Module -Refresh -ListAvailable
-            Write-Debug -Message "Reverting PSModulePath"
-            $env:PSModulePath = $OldPSModulePath
+            Write-Debug -Message 'Discovering modules from folder'
+            $allModulesInFolder += Get-Module -Refresh -ListAvailable
+            Write-Debug -Message 'Reverting PSModulePath'
+            $env:PSModulePath = $oldPSModulePath
         }
     }
 
-    End {
+    End
+    {
 
-        $AllModulesInFolder | Where-Object {
+        $allModulesInFolder | Where-Object {
             $source = $_
-            Write-Debug -message "Checking if Module $source is Excluded."
-            $isExcluded = foreach ($ExcludedModule in $ExcludedModules) {
-                Write-Debug "`t Excluded Module $ExcludedModule"
-                if ( ($ExcludedModule.Name -and $ExcludedModule.Name -eq $source.Name) -and 
+            Write-Debug -Message "Checking if module '$source' is sxcluded."
+            $isExcluded = foreach ($excludedModule in $ExcludedModules)
+            {
+                Write-Debug "`t Excluded module '$ExcludedModule'"
+                if (($excludedModule.Name -and $excludedModule.Name -eq $source.Name) -and
                     (
-                        ( !$ExcludedModule.Version -and 
-                            !$ExcludedModule.Guid -and 
-                            !$ExcludedModule.MaximumVersion -and 
-                            !$ExcludedModule.RequiredVersion ) -or
-                        ($ExcludedModule.Version -and $ExcludedModule.Version -eq $source.Version) -or
-                        ($ExcludedModule.Guid -and $ExcludedModule.Guid -ne $source.Guid) -or
-                        ($ExcludedModule.MaximumVersion -and $ExcludedModule.MaximumVersion -ge $source.Version) -or
-                        ($ExcludedModule.RequiredVersion -and $ExcludedModule.RequiredVersion -eq $source.Version)
+                        (-not $excludedModule.Version -and
+                        -not $excludedModule.Guid -and
+                        -not $excludedModule.MaximumVersion -and
+                        -not $excludedModule.RequiredVersion ) -or
+                        ($excludedModule.Version -and $excludedModule.Version -eq $source.Version) -or
+                        ($excludedModule.Guid -and $excludedModule.Guid -ne $source.Guid) -or
+                        ($excludedModule.MaximumVersion -and $excludedModule.MaximumVersion -ge $source.Version) -or
+                        ($excludedModule.RequiredVersion -and $excludedModule.RequiredVersion -eq $source.Version)
                     )
-                ) {
+                )
+                {
                     Write-Debug ('Skipping {0} {1} {2}' -f $source.Name, $source.Version, $source.Guid)
                     return $false
                 }
             }
-            if (!$isExcluded) {
+            if (-not $isExcluded)
+            {
                 return $true
             }
         }
     }
-    
+
 }

--- a/source/Public/Initialize-DscResourceMetaInfo.ps1
+++ b/source/Public/Initialize-DscResourceMetaInfo.ps1
@@ -35,7 +35,7 @@ function Initialize-DscResourceMetaInfo
     $modulesWithDscResources = $allDscResources | Select-Object -ExpandProperty ModuleName -Unique
     $modulesWithDscResources = $allModules | Where-Object Name -In $modulesWithDscResources
 
-    $standardCimTypes = Get-CimType
+    $standardCimTypes = Get-StandardCimType
 
     $script:allDscResourcePropertiesTable = @{}
 

--- a/source/Public/Initialize-DscResourceMetaInfo.ps1
+++ b/source/Public/Initialize-DscResourceMetaInfo.ps1
@@ -45,12 +45,14 @@ function Initialize-DscResourceMetaInfo
         }
         else
         {
-            Get-DscResourceProperty -ModuleInfo ($modulesWithDscResources |
-                    Where-Object Name -EQ $dscResource.ModuleName) -ResourceName $dscResource.Name |
-                    Where-Object {
-                        $_.TypeConstraint -match '(DSC|MSFT)_.+' -and
-                        $_.TypeConstraint -notin 'MSFT_Credential', 'MSFT_KeyValuePair', 'MSFT_KeyValuePair[]'
-                    }
+            $moduleInfo = $modulesWithDscResources |
+                Where-Object { $_.Name -EQ $dscResource.ModuleName -and $_.Version -eq $dscResource.Version }
+
+            Get-DscResourceProperty -ModuleInfo $moduleInfo -ResourceName $dscResource.Name |
+                Where-Object {
+                    $_.TypeConstraint -match '(DSC|MSFT)_.+' -and
+                    $_.TypeConstraint -notin 'MSFT_Credential', 'MSFT_KeyValuePair', 'MSFT_KeyValuePair[]'
+                }
         }
 
         foreach ($cimProperty in $cimProperties)

--- a/source/Public/Initialize-DscResourceMetaInfo.ps1
+++ b/source/Public/Initialize-DscResourceMetaInfo.ps1
@@ -35,6 +35,8 @@ function Initialize-DscResourceMetaInfo
     $modulesWithDscResources = $allDscResources | Select-Object -ExpandProperty ModuleName -Unique
     $modulesWithDscResources = $allModules | Where-Object Name -In $modulesWithDscResources
 
+    $standardCimTypes = Get-CimType
+
     $script:allDscResourcePropertiesTable = @{}
 
     $script:allDscResourceProperties = foreach ($dscResource in $allDscResources)
@@ -49,10 +51,7 @@ function Initialize-DscResourceMetaInfo
         else
         {
             Get-DscResourceProperty -ModuleInfo $moduleInfo -ResourceName $dscResource.Name |
-                Where-Object {
-                    $_.TypeConstraint -match '(DSC|MSFT)_.+' -and
-                    $_.TypeConstraint -notin 'MSFT_Credential', 'MSFT_KeyValuePair', 'MSFT_KeyValuePair[]'
-                }
+            Where-Object TypeConstraint -NotIn $standardCimTypes.CimType
         }
 
         foreach ($cimProperty in $cimProperties)

--- a/source/Public/Initialize-DscResourceMetaInfo.ps1
+++ b/source/Public/Initialize-DscResourceMetaInfo.ps1
@@ -39,15 +39,15 @@ function Initialize-DscResourceMetaInfo
 
     $script:allDscResourceProperties = foreach ($dscResource in $allDscResources)
     {
+        $moduleInfo = $modulesWithDscResources |
+                Where-Object { $_.Name -EQ $dscResource.ModuleName -and $_.Version -eq $dscResource.Version }
+
         $cimProperties = if ($ReturnAllProperties)
         {
-            Get-DscResourceProperty -ModuleInfo ($modulesWithDscResources | Where-Object Name -EQ $dscResource.ModuleName) -ResourceName $dscResource.Name
+            Get-DscResourceProperty -ModuleInfo $moduleInfo -ResourceName $dscResource.Name
         }
         else
         {
-            $moduleInfo = $modulesWithDscResources |
-                Where-Object { $_.Name -EQ $dscResource.ModuleName -and $_.Version -eq $dscResource.Version }
-
             Get-DscResourceProperty -ModuleInfo $moduleInfo -ResourceName $dscResource.Name |
                 Where-Object {
                     $_.TypeConstraint -match '(DSC|MSFT)_.+' -and


### PR DESCRIPTION
- Initialize-DscResourceMetaInfo:
  - No longer filtering DSC resource properties by name. Now all properties are considered as CIM Instanced / class-based properties that are not standard DSC data types.
  - Fixed non-working caching test.
  - Added PassThru pattern for easier debugging.
- Get-DscResourceFromModuleInFolder:
  - Redesigned the function. It did not work with PowerShell 7 and
    PSDesiredStateConfiguration 2.0.7.
- Get-StandardCimType
  - Added new function that returns all known DSC data types.
- Get-DscResourceProperty
  - Support for class-based resources and complex class-based parameters.
  - The .net data type is returned along with the DSC metadata.
- Get-DscSplattedResource
  - Support for class-based resources and complex class-based parameters.
- Changed the remaining lines in alignment to PR #14.