### PR TITLE
Update changelog for version 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2024-11-09
+
 ### Changed
 
 - Updated build scripts.


### PR DESCRIPTION
For some reason, the task 'Create_ChangeLog_GitHub_PR' did not pickup the changes and did not create a PR for the version 0.2.3. This PR updates the changelog accordingly.

https://synedgy.visualstudio.com/DscBuildHelpers/_build/results?buildId=2129&view=logs&jobId=5d0a9c4e-8741-5118-af45-406a30fe661c&j=5d0a9c4e-8741-5118-af45-406a30fe661c&t=3a8441ac-3281-543a-a59b-2281a9b300f9