### PR TITLE
Added tests for 'Get-DscResourceProperty' and fixed some issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enabled all tests in 'Get-DscSplattedResource.Integration.Tests.ps1'.
+- Improved module import handling and getting the module info from 'Get-Module' if
+  already imported.
 
 ### Added
 
@@ -20,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 'Write-CimPropertyValue'.
   - 'Get-DscResourceProperty'.
   - 'Initialize-DscResourceMetaInfo'.
+- Add integration tests for Get-DscResourceProperty function.
+  - Add latest versions of' NetworkingDsc', 'ComputermanagementDsc', and Microsoft365DSC
+    to 'RequiredModules.psd1' for 'Get-DscResourceProperty' integration tests.
+
+### Fixed
+
+- Fixed null reference check for array type in 'Get-DscResourceProperty' function.
+  An error was thrown that the property 'IsArray' could not be found.
 
 ## [0.2.3] - 2024-11-09
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -25,5 +25,8 @@
 
     xDscResourceDesigner         = 'latest'
     xPSDesiredStateConfiguration = 'latest'
+    NetworkingDsc                = 'latest'
+    ComputermanagementDsc        = 'latest'
+    Microsoft365DSC              = 'latest'
 
 }

--- a/source/Private/Get-DscResourceProperty.ps1
+++ b/source/Private/Get-DscResourceProperty.ps1
@@ -109,7 +109,7 @@ function Get-DscResourceProperty
                 Write-Verbose "The type '$TypeName' could not be resolved."
             }
 
-            if ($result.Type.IsArray)
+            if ($result.Type -and $result.Type.IsArray)
             {
                 $result.ElementType = $result.Type.GetElementType().FullName
                 $result.IsArray = $true

--- a/source/Private/Get-DscResourceProperty.ps1
+++ b/source/Private/Get-DscResourceProperty.ps1
@@ -56,13 +56,27 @@ function Get-DscResourceProperty
         $ResourceName
     )
 
-    $ModuleInfo = if ($ModuleName)
+    if ($ModuleName)
     {
-        Import-Module -Name $ModuleName -PassThru -Force
+        if (Get-Module -Name $ModuleName)
+        {
+            $ModuleInfo = Get-Module -Name $ModuleName
+        }
+        else
+        {
+            $ModuleInfo = Import-Module -Name $ModuleName -PassThru -Force
+        }
     }
     else
     {
-        Import-Module -Name $ModuleInfo.Name -PassThru -Force
+        if (Get-Module -Name $ModuleInfo.Name)
+        {
+            $ModuleInfo = Get-Module -Name $ModuleInfo.Name
+        }
+        else
+        {
+            $ModuleInfo = Import-Module -Name $ModuleInfo.Name -PassThru -Force
+        }
     }
 
     [Microsoft.PowerShell.DesiredStateConfiguration.Internal.DscClassCache]::ClearCache()

--- a/tests/Integration/Get-DscResourceProperty.Integration.Tests.ps1
+++ b/tests/Integration/Get-DscResourceProperty.Integration.Tests.ps1
@@ -1,0 +1,47 @@
+BeforeDiscovery {
+
+    Import-Module -Name DscBuildHelpers -Force
+
+    $allModules = Get-ModuleFromFolder -ModuleFolder $requiredModulesPath
+    $allDscResources = Get-DscResourceFromModuleInFolder -ModuleFolder $requiredModulesPath -Modules $allModules
+    $modulesWithDscResources = $allDscResources | Select-Object -ExpandProperty ModuleName -Unique
+    $modulesWithDscResources = $allModules | Where-Object Name -In $modulesWithDscResources
+
+    [hashtable[]]$testCases = @()
+    foreach ($dscResource in $allDscResources)
+    {
+        $testCases += @{
+            DscResourceName            = $dscResource.Name
+            DscResourceType            = $dscResource.ImplementedAs
+            DscResourceProperties      = $dscResource.Properties
+            DscResourcePropertiesCount = $dscResource.Properties.Count
+            DscModuleName              = $dscResource.ModuleName
+        }
+    }
+}
+
+Describe 'Get-DscResourceProperty Tests' -Tags FunctionalQuality {
+
+    It "'Get-DscResourceProperty' with '<DscResourceName>' does not throw" -TestCases $testCases {
+
+        InModuleScope DscBuildHelpers -Parameters $_ {
+            {
+                Get-DscResourceProperty -ModuleName $DscModuleName -ResourceName $DscResourceName -ErrorAction Stop
+            } | Should -Not -Throw
+        }
+    }
+
+    It "'Get-DscResourceProperty' with '<DscResourceName>' returns <DscResourcePropertiesCount> properties" -TestCases $testCases {
+
+        if ($DscResourceType -eq 'Composite')
+        {
+            Set-ItResult -Skipped -Because "Composite DSC resources are not supported"
+        }
+
+        InModuleScope DscBuildHelpers -Parameters $_ {
+            $result = Get-DscResourceProperty -ModuleName $DscModuleName -ResourceName $DscResourceName
+            $result.Count | Should -Be $DscResourceProperties.Count
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request includes several changes to improve module import handling, add integration tests, and fix a bug in the `Get-DscResourceProperty` function. The changes are organized into improvements, additions, and fixes.

Improvements to module import handling:

* [`source/Private/Get-DscResourceProperty.ps1`](diffhunk://#diff-b2df524eb47bf486f4e327f74530d5c692a682e552bbafaf6176ae9b6568927aL59-R79): Enhanced the module import logic to check if the module is already imported using `Get-Module` before importing it. [[1]](diffhunk://#diff-b2df524eb47bf486f4e327f74530d5c692a682e552bbafaf6176ae9b6568927aL59-R79) [[2]](diffhunk://#diff-b2df524eb47bf486f4e327f74530d5c692a682e552bbafaf6176ae9b6568927aL112-R126)

Additions:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR25-R32): Added integration tests for the `Get-DscResourceProperty` function and updated `RequiredModules.psd1` to include the latest versions of `NetworkingDsc`, `ComputermanagementDsc`, and `Microsoft365DSC`.
* [`tests/Integration/Get-DscResourceProperty.Integration.Tests.ps1`](diffhunk://#diff-bc5989723dfe2f49909c79272dc2afbd2de35247da9baf1f11d63c42519d42efR1-R47): Added new integration tests for the `Get-DscResourceProperty` function.
* [`RequiredModules.psd1`](diffhunk://#diff-ee10b2e39d5d3ab414c10a7e24fff3d075d1f6ba0b9255eefb8f55ab6718920cR28-R30): Updated to include the latest versions of `NetworkingDsc`, `ComputermanagementDsc`, and `Microsoft365DSC`.

Bug fixes:

* [`source/Private/Get-DscResourceProperty.ps1`](diffhunk://#diff-b2df524eb47bf486f4e327f74530d5c692a682e552bbafaf6176ae9b6568927aL112-R126): Fixed a null reference check for the array type in the `Get-DscResourceProperty` function to prevent errors when the `IsArray` property could not be found.