### PR TITLE
Fixed a bug in 'Initialize-DscResourceMetaInfo' and added test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 'Get-DscResourceProperty'.
   - 'Initialize-DscResourceMetaInfo'.
 - Add integration tests for Get-DscResourceProperty function.
-  - Add latest versions of' NetworkingDsc', 'ComputermanagementDsc', and Microsoft365DSC
+  - Add latest versions of' NetworkingDsc', 'ComputermanagementDsc', and 'Microsoft365DSC'
     to 'RequiredModules.psd1' for 'Get-DscResourceProperty' integration tests.
+- Added integration test for 'Initialize-DscResourceMetaInfo' and added 'SharePointDsc'.
 
 ### Fixed
 
 - Fixed null reference check for array type in 'Get-DscResourceProperty' function.
   An error was thrown that the property 'IsArray' could not be found.
+- Fixed a bug in 'Initialize-DscResourceMetaInfo' when importing for example
+  'SharePointDsc', which returns 2 objects.
 
 ## [0.2.3] - 2024-11-09
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -28,5 +28,6 @@
     NetworkingDsc                = 'latest'
     ComputermanagementDsc        = 'latest'
     Microsoft365DSC              = 'latest'
+    SharePointDsc                = 'latest'
 
 }

--- a/source/Private/Get-DscResourceProperty.ps1
+++ b/source/Private/Get-DscResourceProperty.ps1
@@ -64,7 +64,7 @@ function Get-DscResourceProperty
         }
         else
         {
-            $ModuleInfo = Import-Module -Name $ModuleName -PassThru -Force
+            $ModuleInfo = Import-Module -Name $ModuleName -PassThru -Force | Where-Object Name -eq $ModuleName
         }
     }
     else
@@ -75,7 +75,7 @@ function Get-DscResourceProperty
         }
         else
         {
-            $ModuleInfo = Import-Module -Name $ModuleInfo.Name -PassThru -Force
+            $ModuleInfo = Import-Module -Name $ModuleInfo.Name -PassThru -Force | Where-Object Name -eq $ModuleInfo.Name
         }
     }
 

--- a/source/Public/Initialize-DscResourceMetaInfo.ps1
+++ b/source/Public/Initialize-DscResourceMetaInfo.ps1
@@ -69,6 +69,19 @@ function Initialize-DscResourceMetaInfo
         }
     }
 
+    if (-not (Test-Path -Path $ModulePath))
+    {
+        Write-Error -Message "The module path '$ModulePath' does not exist."
+        return
+    }
+
+    $allModules = Get-ModuleFromFolder -ModuleFolder $ModulePath
+    if ($null -eq $allModules -or $allModules.Count -eq 0)
+    {
+        Write-Error -Message "No modules found in the module path '$ModulePath'."
+        return
+    }
+
     $allModules = Get-ModuleFromFolder -ModuleFolder $ModulePath
     $allDscResources = Get-DscResourceFromModuleInFolder -ModuleFolder $ModulePath -Modules $allModules
     $modulesWithDscResources = $allDscResources | Select-Object -ExpandProperty ModuleName -Unique

--- a/tests/Integration/Initialize-DscResourceMetaInfo.Tests.ps1
+++ b/tests/Integration/Initialize-DscResourceMetaInfo.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeDiscovery {
+BeforeAll {
 
     $here = $PSScriptRoot
 

--- a/tests/Integration/Initialize-DscResourceMetaInfo.Tests.ps1
+++ b/tests/Integration/Initialize-DscResourceMetaInfo.Tests.ps1
@@ -1,0 +1,19 @@
+BeforeDiscovery {
+
+    $here = $PSScriptRoot
+
+    Import-Module -Name datum
+    Import-Module -Name DscBuildHelpers -Force
+
+}
+
+Describe 'Initialize-DscResourceMetaInfo' -Tags FunctionalQuality {
+
+    It "'Initialize-DscResourceMetaInfo' does not throw" {
+
+        {
+            Initialize-DscResourceMetaInfo -ModulePath $requiredModulesPath -Force -ErrorAction Stop
+        } | Should -Not -Throw
+    }
+
+}

--- a/tests/Integration/Initialize-DscResourceMetaInfo.Tests.ps1
+++ b/tests/Integration/Initialize-DscResourceMetaInfo.Tests.ps1
@@ -5,15 +5,63 @@ BeforeAll {
     Import-Module -Name datum
     Import-Module -Name DscBuildHelpers -Force
 
+    $tempPath = Join-Path -Path ([IO.Path]::GetTempPath()) -ChildPath DscTest
+    mkdir -Path $tempPath -Force
+
+    $env:PSModulePath = "$tempPath;$($env:PSModulePath)"
+
+}
+
+AfterAll {
+
+    Remove-Item -Path $tempPath -Recurse -Force
+
 }
 
 Describe 'Initialize-DscResourceMetaInfo' -Tags FunctionalQuality {
 
     It "'Initialize-DscResourceMetaInfo' does not throw" {
-
         {
             Initialize-DscResourceMetaInfo -ModulePath $requiredModulesPath -Force -ErrorAction Stop
         } | Should -Not -Throw
+    }
+
+    It "'Initialize-DscResourceMetaInfo' throws for non-existing path" {
+        {
+            Initialize-DscResourceMetaInfo -ModulePath 'C:\NonExistingPath' -Force -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage "The module path 'C:\NonExistingPath' does not exist."
+    }
+
+    It "'Initialize-DscResourceMetaInfo' throws when no modules are in the path" {
+        {
+            Initialize-DscResourceMetaInfo -ModulePath $tempPath -Force -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage "No modules found in the module path '$tempPath'."
+    }
+
+    It "'Initialize-DscResourceMetaInfo' does not throw accessing temp path with 2 modules" {
+
+        dir -Path $here\Assets\DscResources\* -Directory | Copy-Item -Destination $tempPath -Recurse -Force
+
+        {
+            Initialize-DscResourceMetaInfo -ModulePath $tempPath -Force -ErrorAction Stop
+        } | Should -Not -Throw
+    }
+
+    It "'Initialize-DscResourceMetaInfo' gathered the expected data" {
+
+        $param = @{
+            TempPath = $tempPath
+        }
+
+        Initialize-DscResourceMetaInfo -ModulePath $tempPath -Force -ErrorAction Stop
+
+        InModuleScope DscBuildHelpers -Parameters $param {
+
+
+            $allDscResourceProperties.Count | Should -Be 10
+            $allDscResourcePropertiesTable.Count | Should -Be 10
+            $allDscSchemaClasses.Count | Should -Be 9
+        }
     }
 
 }


### PR DESCRIPTION
This fixes a bug in `Initialize-DscResourceMetaInfo`. `Import-Module` returns two objects when importing for example `SharePointDsc`:

```
PS C:\Git\DscBuildHelpers> import-Module SharePointDSC -PassThru

ModuleType Version    PreRelease Name                                ExportedCommands
---------- -------    ---------- ----                                ----------------
Script     0.0                   Import-SPPowerShellSnapIn
Manifest   5.5.0                 SharePointDSC                       {Add-SPDscEvent, Add-SPDscUserToLocalAdmin, Clear-SPDscKerberosToken, …
```

Added a filter to return only the relevant object.